### PR TITLE
Prevent auth bypass when including `/cfp_login` in the URL

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -15,6 +15,8 @@ export async function onRequest(context: {
 
   if (
     cookie.includes(cookieKeyValue) ||
+    // allow the request to cfp_login only if it is a POST request
+    (request.method == "POST" && pathname === '/cfp_login') ||
     CFP_ALLOWED_PATHS.includes(pathname) ||
     !env.CFP_PASSWORD
   ) {

--- a/functions/constants.ts
+++ b/functions/constants.ts
@@ -11,6 +11,5 @@ export const CFP_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 
 /**
  * Paths that don't require authentication.
- * The /cfp_login path must be included.
  */
-export const CFP_ALLOWED_PATHS = ['/cfp_login'];
+export const CFP_ALLOWED_PATHS = [];


### PR DESCRIPTION
Closes https://github.com/Charca/cloudflare-pages-auth/issues/9

Instead of including `/cfp_login` in the CFP_ALLOWED_PATHS list, we check to ensure it matches that path AND is using a POST request.
